### PR TITLE
Add test case for FetchInvalidMethodException

### DIFF
--- a/DotnetFetch.Tests/FetchTests.cs
+++ b/DotnetFetch.Tests/FetchTests.cs
@@ -18,6 +18,19 @@ namespace DotnetFetch.Tests
         }
 
         [Fact]
+        public async void FetchInvalidMethodShouldThrowException()
+        {
+            var fetchOptions = new JsonObject();
+            options["method"] = "invalid";
+            Assert.Throws<FetchInvalidMethodException>(
+                () => await GlobalFetch.Fetch(
+                    "https://jsonplaceholder.typicode.com/todos/1",
+                    fetchOptions
+                )
+            );
+        }
+
+        [Fact]
         public async void FetchGenericFunctionShouldWorkProperly()
         {
 

--- a/DotnetFetch.Tests/FetchTests.cs
+++ b/DotnetFetch.Tests/FetchTests.cs
@@ -21,7 +21,7 @@ namespace DotnetFetch.Tests
         public async void FetchInvalidMethodShouldThrowException()
         {
             var fetchOptions = new JsonObject();
-            options["method"] = "invalid";
+            fetchOptions["method"] = "invalid";
             Assert.Throws<FetchInvalidMethodException>(
                 () => await GlobalFetch.Fetch(
                     "https://jsonplaceholder.typicode.com/todos/1",


### PR DESCRIPTION
Solves #5.

A new test case has been added, which ensures the Fetch Invalid Method exception functionality.

The given changes **require testing**, as no environment has been set up for testing it locally.

Could you kindly review the changes and run the test suite for possible changes considering that this is my first contribution @victoriaquasar? Thank you in advance!

