### PR TITLE
Corrected spelling of `exception` in `FetchCorsException` message.

### DIFF
--- a/DotnetFetch/Models/FetchCorsException.cs
+++ b/DotnetFetch/Models/FetchCorsException.cs
@@ -11,6 +11,6 @@
         /// Creates a new <see cref="FetchCorsException"/> with a default message.
         /// </summary>
         public FetchCorsException()
-            : base("A CORS excepion has occurred, check your request options") { }
+            : base("A CORS exception has occurred, check your request options.") { }
     }
 }


### PR DESCRIPTION
This PR simply corrects the spelling of `exception` in the message for `FetchCorsException`.