### PR TITLE
Added support for VS Code.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.vscodeintellicode-csharp"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "DotnetFetch.sln",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/DotnetFetch/DotnetFetch.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
This PR introduces support for VS Code as an IDE by adding the following:

- Recommended extensions:
  - [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
  - [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit)
  - [IntelliCode for C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.vscodeintellicode-csharp)
- Standard tasks:
  - Build
  - Publish
- Settings:
  - Default solution for C# Dev Kit

Normally, a `watch` task is also created for supporting C# repositories in VS Code, but in this case there isn't a project to actually watch so it is currently redundant. However, if it ever becomes prevalent, one could simply add the following to the `tasks.json` file:

```json
{
    "version": "2.0.0",
    "tasks": [
        ...
        {
            "label": "watch",
            "command": "dotnet",
            "type": "process",
            "args": [
                "watch",
                "run",
                "--project",
                "${workspaceFolder}/DotnetFetch.Tests/DotnetFetch.Tests.csproj"
            ],
            "problemMatcher": "$msCompile"
        }
    ]
}
```

Finally, I'd like to point out that the C# Dev Kit automatically adds an entry in `settings.json` for the default solution, which is strange behavior compared to the average extension (in my experience at least).